### PR TITLE
feat: add SplitButton widget

### DIFF
--- a/lib/src/theme/m3e_split_button_theme_data.dart
+++ b/lib/src/theme/m3e_split_button_theme_data.dart
@@ -1,0 +1,28 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+@immutable
+class M3ESplitButtonThemeData with Diagnosticable {
+  final double? spacing;
+
+  const M3ESplitButtonThemeData({this.spacing});
+
+  static M3ESplitButtonThemeData? lerp(
+    M3ESplitButtonThemeData? a,
+    M3ESplitButtonThemeData? b,
+    double t,
+  ) {
+    return switch ((a, b)) {
+      (null, null) => null,
+      (null, final b?) => b,
+      (final a?, null) => a,
+      (final a?, final b?) =>
+        identical(a, b)
+            ? a
+            : M3ESplitButtonThemeData(
+              spacing: lerpDouble(a.spacing, b.spacing, t),
+            ),
+    };
+  }
+}

--- a/lib/src/theme/m3e_theme.dart
+++ b/lib/src/theme/m3e_theme.dart
@@ -1,22 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:material_expressive/src/theme/m3e_split_button_theme_data.dart';
 import 'package:material_expressive/src/theme/motion_scheme.dart';
 
 import 'm3e_floating_action_button_theme_data.dart';
 
 class M3ETheme extends ThemeExtension<M3ETheme> {
-  const M3ETheme({this.floatingActionButtonTheme})
+  const M3ETheme({this.floatingActionButtonTheme, this.splitButtonTheme})
     : motionScheme = const M3EMotionScheme();
 
   final MotionScheme motionScheme;
   final M3EFloatingActionButtonThemeData? floatingActionButtonTheme;
+  final M3ESplitButtonThemeData? splitButtonTheme;
 
   @override
   M3ETheme copyWith({
     M3EFloatingActionButtonThemeData? floatingActionButtonTheme,
+    M3ESplitButtonThemeData? splitButtonTheme,
   }) {
     return M3ETheme(
       floatingActionButtonTheme:
           floatingActionButtonTheme ?? this.floatingActionButtonTheme,
+      splitButtonTheme: splitButtonTheme ?? this.splitButtonTheme,
     );
   }
 
@@ -27,6 +31,11 @@ class M3ETheme extends ThemeExtension<M3ETheme> {
       floatingActionButtonTheme: M3EFloatingActionButtonThemeData.lerp(
         floatingActionButtonTheme,
         other.floatingActionButtonTheme,
+        t,
+      ),
+      splitButtonTheme: M3ESplitButtonThemeData.lerp(
+        splitButtonTheme,
+        other.splitButtonTheme,
         t,
       ),
     );

--- a/lib/src/widgets/buttons/m3e_split_button.dart
+++ b/lib/src/widgets/buttons/m3e_split_button.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:material_expressive/material_expressive.dart';
+import 'package:material_expressive/src/theme/m3e_split_button_theme_data.dart';
+import 'package:material_expressive/src/utils/debug_check_has_expressive_material.dart';
+
+/// A [M3ESplitButton] lets a user define a button group consisting of 2 buttons.
+/// The leading button performs a primary action, and the trailing button performs
+/// a secondary action that is contextually related to the primary action.
+class M3ESplitButton extends StatelessWidget {
+  const M3ESplitButton({
+    super.key,
+    required this.leading,
+    required this.trailing,
+    this.spacing,
+  });
+
+  /// A [Widget] representing the leading button in a split button group.
+  final Widget leading;
+
+  /// A [Widget] representing the trailing button in a split button group.
+  final Widget trailing;
+
+  /// The horizontal spacing between the leading and trailing buttons.
+  ///
+  /// If this property is null, then the [M3ESplitButtonThemeData.spacing]
+  /// of [ThemeData.splitButtonTheme] is used. If that property is also
+  /// null, then the default spacing value (2.0) is used.
+  final double? spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    debugCheckHasExpressiveMaterial(context);
+
+    final M3ESplitButtonThemeData? theme =
+        Theme.of(context).extension<M3ETheme>()?.splitButtonTheme;
+    final effectiveSpacing =
+        spacing ?? theme?.spacing ?? _M3ESplitButtonDefaults.spacing;
+
+    return Row(
+      children: [leading, SizedBox(width: effectiveSpacing), trailing],
+    );
+  }
+}
+
+/// Default values for [M3ESplitButton]
+class _M3ESplitButtonDefaults {
+  static const spacing = 2.0;
+}


### PR DESCRIPTION
Implements: #13

I gonna do the LeadingButton and TrailingButton Widget in a second time. This PR only contains SplitButtonLayout equivalent.